### PR TITLE
buildsys: integrate autotools in the build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,47 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+ACLOCAL_AMFLAGS = -I confdb
+
+AM_CFLAGS   = $(CFLAGS)
+AM_CPPFLAGS = $(CPPFLAGS)
+AM_LDFLAGS  = $(LDFLAGS)
+
+pfm_sources =
+examples_list =
+perf_examples_list =
+testlist =
+dist_noinst_SCRIPTS = autogen.sh
+noinst_HEADERS =
+bin_PROGRAMS =
+include_HEADERS =
+man_MANS =
+EXTRA_PROGRAMS =
+EXTRA_DIST = README COPYING
+
+include $(top_srcdir)/lib/Makefile.mk
+include $(top_srcdir)/tests/Makefile.mk
+include $(top_srcdir)/include/Makefile.mk
+include $(top_srcdir)/docs/Makefile.mk
+include $(top_srcdir)/perf_examples/Makefile.mk
+include $(top_srcdir)/examples/Makefile.mk
+
+if EMBEDDED_BUILD
+noinst_LTLIBRARIES = libpfm.la
+libpfm_la_LDFLAGS = $(AM_LDFLAGS) -avoid-version
+else
+lib_LTLIBRARIES = libpfm.la
+libpfm_la_LDFLAGS = $(AM_LDFLAGS) $(PFMLIB_VERSION)
+endif
+
+libpfm_la_SOURCES  = $(pfm_sources)
+libpfm_la_CPPFLAGS = $(AM_CPPFLAGS)
+libpfm_la_LIBADD   = $(LIBS)
+
+perf_examples: $(perf_examples_list)
+
+examples: $(examples_list)
+
+tests: $(testlist)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+autoreconf -ivf

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,177 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+m4_include([maint/version.m4])
+
+AC_PREREQ([2.69])
+AC_INIT([PFM],
+        PFM_VERSION_m4,
+        [eranian@gmail.com],
+        [pfm],
+        [http://perfmon2.sourceforge.net])
+
+AC_CONFIG_SRCDIR([examples/check_events.c])
+AC_CONFIG_HEADERS([config.h])
+
+AC_CONFIG_AUX_DIR([confdb])
+AC_CONFIG_MACRO_DIR([confdb])
+
+AC_CANONICAL_TARGET
+AC_CANONICAL_BUILD
+AC_CANONICAL_HOST
+
+AC_USE_SYSTEM_EXTENSIONS
+
+PFMLIB_VERSION="-release PFM_VERSION_m4"
+AC_SUBST(PFMLIB_VERSION)
+
+# Enable Automake
+AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+AM_PROG_AR
+AM_SILENT_RULES([yes])
+
+# Enable Libtool support
+LT_INIT()
+
+# Checks for programs.
+AC_PROG_CC
+AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_PROG_MAKE_SET
+
+# Checks for config parameters
+AS_CASE([$host_os],
+        [linux*], [
+                   CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_OS_LINUX"
+                   CONFIG_PFMLIB_NOPYTHON=y
+                   CONFIG_PFMLIB_OS_LINUX=y
+                  ],
+        [cygwin*|mingw*],
+                  [
+                   CPPFLAGS="$CPPFLAGS -DPFMLIB_WINDOWS"
+                   CONFIG_PFMLIB_OS_WINDOWS=y
+                  ],
+        [])
+
+AS_CASE([$host_cpu],
+        [ia64],   [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_IA64"],
+        [x86_64], [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_X86 -DCONFIG_PFMLIB_ARCH_X86_64"],
+        [i386],   [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_I386"],
+        [mips],   [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_MIPS"],
+        [powerpc],[CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_POWERPC"],
+        [sparc],  [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_SPARC"],
+        [arm],    [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_ARM"],
+        [aarch64],[CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_ARM64"],
+        [arm64],  [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_ARM64"],
+        [s390x],  [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_S390X"],
+        [cell],   [CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_ARCH_CELL"],
+        [])
+
+AC_ARG_ENABLE([debug],
+              [AC_HELP_STRING([--enable-debug],
+                              [Build libpfm with debug symbols])],
+              [
+               CFLAGS="$CFLAGS -g"
+               CPPFLAGS="$CPPFLAGS -DCONFIG_PFMLIB_DEBUG"
+              ],
+              [])
+
+AC_ARG_ENABLE([embedded],
+              [AS_HELP_STRING([--enable-embedded],
+                              [Enables embedded builds])],
+              [enable_embedded=y],
+              [enable_embedded=n])
+
+CFLAGS="$CFLAGS -O2"
+
+AC_MSG_CHECKING([for ncurses devel])
+LIBS=-lncurses
+AC_LINK_IFELSE([AC_LANG_SOURCE([
+                                #include <ncurses.h>
+                                int main(void) {
+                                    printw();
+                                    return 0;
+                                }
+                               ])],
+               [
+                have_ncurses_dev=y
+                AC_MSG_RESULT([yes])
+               ],
+               [
+                have_ncurses_dev=n
+                AC_MSG_RESULT([no])
+                LIBS=
+               ])
+
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_IA64],   [test "$host_cpu" = "ia64"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_X86],    [test "$host_cpu" = "x86_64"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_I386],   [test "$host_cpu" = "i386"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_MIPS],   [test "$host_cpu" = "mips"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_POWERPC],[test "$host_cpu" = "powerpc"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_SPARC],  [test "$host_cpu" = "sparc"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_ARM],    [test "$host_cpu" = "arm"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_ARM64],  [test "$host_cpu" = "aarch64"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_ARM64],  [test "$host_cpu" = "arm64"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_S390X],  [test "$host_cpu" = "s390x"])
+AM_CONDITIONAL([BUILD_PFMLIB_ARCH_CELL],   [test "$host_cpu" = "cell"])
+AM_CONDITIONAL([BUILD_PFMLIB_NOPYTHON],    [test "x$CONFIG_PFMLIB_NOPYTHON" = "xy"])
+AM_CONDITIONAL([BUILD_PFMLIB_OS_LINUX],    [test "x$CONFIG_PFMLIB_OS_LINUX" = "xy"])
+AM_CONDITIONAL([BUILD_PFMLIB_OS_WINDOWS],  [test "x$CONFIG_PFMLIB_OS_WINDOWS" = "xy"])
+AM_CONDITIONAL([BUILD_RTOP],               [test "x$have_ncurses_dev" = "xy"])
+AM_CONDITIONAL([EMBEDDED_BUILD],           [test "x$enable_embedded" = "xy"])
+
+# Checks for header files.
+AC_CHECK_HEADERS([fcntl.h     \
+                  inttypes.h  \
+                  limits.h    \
+                  locale.h    \
+                  malloc.h    \
+                  stdlib.h    \
+                  string.h    \
+                  sys/ioctl.h \
+                  sys/param.h \
+                  sys/time.h  \
+                  termios.h   \
+                  unistd.h])
+
+# Checks for typedefs, structures, and compiler characteristics.
+AC_C_INLINE
+AC_TYPE_INT32_T
+AC_TYPE_INT64_T
+AC_TYPE_PID_T
+AC_TYPE_SIZE_T
+AC_TYPE_SSIZE_T
+AC_TYPE_UINT16_T
+AC_TYPE_UINT32_T
+AC_TYPE_UINT64_T
+AC_TYPE_UINT8_T
+
+# Checks for library functions.
+AC_FUNC_FORK
+AC_FUNC_MALLOC
+AC_FUNC_MMAP
+AC_FUNC_REALLOC
+AC_CHECK_FUNCS([alarm        \
+                getpagesize  \
+                gettimeofday \
+                memset       \
+                munmap       \
+                putenv       \
+                regcomp      \
+                setenv       \
+                setlocale    \
+                strcasecmp   \
+                strchr       \
+                strdup       \
+                strerror     \
+                strncasecmp  \
+                strpbrk      \
+                strstr       \
+                strtol       \
+                strtoul      \
+                strtoull])
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/docs/Makefile.mk
+++ b/docs/Makefile.mk
@@ -1,0 +1,142 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+man_MANS +=                                   \
+    docs/man3/libpfm.3                        \
+    docs/man3/pfm_find_event.3                \
+    docs/man3/pfm_get_event_attr_info.3       \
+    docs/man3/pfm_get_event_info.3            \
+    docs/man3/pfm_get_event_encoding.3        \
+    docs/man3/pfm_get_event_next.3            \
+    docs/man3/pfm_get_pmu_info.3              \
+    docs/man3/pfm_get_os_event_encoding.3     \
+    docs/man3/pfm_get_version.3               \
+    docs/man3/pfm_initialize.3                \
+    docs/man3/pfm_terminate.3                 \
+    docs/man3/pfm_strerror.3
+
+if BUILD_PFMLIB_ARCH_X86
+man_MANS +=                                   \
+    docs/man3/libpfm_intel_core.3             \
+    docs/man3/libpfm_intel_x86_arch.3         \
+    docs/man3/libpfm_amd64.3                  \
+    docs/man3/libpfm_amd64_k7.3               \
+    docs/man3/libpfm_amd64_k8.3               \
+    docs/man3/libpfm_amd64_fam10h.3           \
+    docs/man3/libpfm_amd64_fam15h.3           \
+    docs/man3/libpfm_amd64_fam16h.3           \
+    docs/man3/libpfm_amd64_fam17h.3           \
+    docs/man3/libpfm_amd64_fam17h_zen2.3      \
+    docs/man3/libpfm_amd64_fam19h_zen3.3      \
+    docs/man3/libpfm_amd64_fam19h_zen4.3      \
+    docs/man3/libpfm_amd64_fam19h_zen3_l3.3   \
+    docs/man3/libpfm_intel_atom.3             \
+    docs/man3/libpfm_intel_nhm.3              \
+    docs/man3/libpfm_intel_nhm_unc.3          \
+    docs/man3/libpfm_intel_wsm.3              \
+    docs/man3/libpfm_intel_wsm_unc.3          \
+    docs/man3/libpfm_intel_snb.3              \
+    docs/man3/libpfm_intel_snb_unc.3          \
+    docs/man3/libpfm_intel_ivb.3              \
+    docs/man3/libpfm_intel_ivb_unc.3          \
+    docs/man3/libpfm_intel_hsw.3              \
+    docs/man3/libpfm_intel_bdw.3              \
+    docs/man3/libpfm_intel_rapl.3             \
+    docs/man3/libpfm_intel_slm.3              \
+    docs/man3/libpfm_intel_tmt.3              \
+    docs/man3/libpfm_intel_skl.3              \
+    docs/man3/libpfm_intel_icl.3              \
+    docs/man3/libpfm_intel_icx.3              \
+    docs/man3/libpfm_intel_spr.3              \
+    docs/man3/libpfm_intel_glm.3              \
+    docs/man3/libpfm_intel_knl.3              \
+    docs/man3/libpfm_intel_knm.3              \
+    docs/man3/libpfm_intel_snbep_unc_cbo.3    \
+    docs/man3/libpfm_intel_snbep_unc_ha.3     \
+    docs/man3/libpfm_intel_snbep_unc_imc.3    \
+    docs/man3/libpfm_intel_snbep_unc_pcu.3    \
+    docs/man3/libpfm_intel_snbep_unc_qpi.3    \
+    docs/man3/libpfm_intel_snbep_unc_ubo.3    \
+    docs/man3/libpfm_intel_snbep_unc_r2pcie.3 \
+    docs/man3/libpfm_intel_snbep_unc_r3qpi.3  \
+    docs/man3/libpfm_intel_ivbep_unc_cbo.3    \
+    docs/man3/libpfm_intel_ivbep_unc_ha.3     \
+    docs/man3/libpfm_intel_ivbep_unc_imc.3    \
+    docs/man3/libpfm_intel_ivbep_unc_pcu.3    \
+    docs/man3/libpfm_intel_ivbep_unc_qpi.3    \
+    docs/man3/libpfm_intel_ivbep_unc_ubo.3    \
+    docs/man3/libpfm_intel_ivbep_unc_r2pcie.3 \
+    docs/man3/libpfm_intel_ivbep_unc_r3qpi.3  \
+    docs/man3/libpfm_intel_ivbep_unc_irp.3    \
+    docs/man3/libpfm_intel_knc.3              \
+    docs/man3/libpfm_intel_hswep_unc_cbo.3    \
+    docs/man3/libpfm_intel_hswep_unc_ha.3     \
+    docs/man3/libpfm_intel_hswep_unc_imc.3    \
+    docs/man3/libpfm_intel_hswep_unc_irp.3    \
+    docs/man3/libpfm_intel_hswep_unc_pcu.3    \
+    docs/man3/libpfm_intel_hswep_unc_qpi.3    \
+    docs/man3/libpfm_intel_hswep_unc_r2pcie.3 \
+    docs/man3/libpfm_intel_hswep_unc_r3qpi.3  \
+    docs/man3/libpfm_intel_hswep_unc_sbo.3    \
+    docs/man3/libpfm_intel_hswep_unc_ubo.3    \
+    docs/man3/libpfm_intel_bdx_unc_cbo.3      \
+    docs/man3/libpfm_intel_bdx_unc_ha.3       \
+    docs/man3/libpfm_intel_bdx_unc_imc.3      \
+    docs/man3/libpfm_intel_bdx_unc_irp.3      \
+    docs/man3/libpfm_intel_bdx_unc_pcu.3      \
+    docs/man3/libpfm_intel_bdx_unc_qpi.3      \
+    docs/man3/libpfm_intel_bdx_unc_r2pcie.3   \
+    docs/man3/libpfm_intel_bdx_unc_r3qpi.3    \
+    docs/man3/libpfm_intel_bdx_unc_sbo.3      \
+    docs/man3/libpfm_intel_bdx_unc_ubo.3      \
+    docs/man3/libpfm_intel_skx_unc_cha.3      \
+    docs/man3/libpfm_intel_skx_unc_imc.3      \
+    docs/man3/libpfm_intel_skx_unc_irp.3      \
+    docs/man3/libpfm_intel_skx_unc_m2m.3      \
+    docs/man3/libpfm_intel_skx_unc_m3upi.3    \
+    docs/man3/libpfm_intel_skx_unc_pcu.3      \
+    docs/man3/libpfm_intel_skx_unc_ubo.3      \
+    docs/man3/libpfm_intel_skx_unc_upi.3      \
+    docs/man3/libpfm_intel_spr.3
+endif # end of BUILD_PFMLIB_ARCH_X86
+
+if BUILD_PFMLIB_ARCH_I386
+man_MANS +=                                   \
+    docs/man3/libpfm_intel_p6.3               \
+    docs/man3/libpfm_intel_coreduo.3
+endif # end of BUILD_PFMLIB_ARCH_I386
+
+if BUILD_PFMLIB_ARCH_ARM
+man_MANS +=                                   \
+    docs/man3/libpfm_arm_xgene.3              \
+    docs/man3/libpfm_arm_ac7.3                \
+    docs/man3/libpfm_arm_ac57.3               \
+    docs/man3/libpfm_arm_ac53.3               \
+    docs/man3/libpfm_arm_ac15.3               \
+    docs/man3/libpfm_arm_ac8.3                \
+    docs/man3/libpfm_arm_ac9.3                \
+    docs/man3/libpfm_arm_qcom_krait.3         \
+    docs/man3/libpfm_arm_neoverse_n1.3        \
+    docs/man3/libpfm_arm_neoverse_n2.3
+endif # end of BUILD_PFMLIB_ARCH_ARM
+
+if BUILD_PFMLIB_ARCH_ARM64
+man_MANS +=                                   \
+    docs/man3/libpfm_arm_xgene.3              \
+    docs/man3/libpfm_arm_ac57.3               \
+    docs/man3/libpfm_arm_ac53.3               \
+    docs/man3/libpfm_arm_a64fx.3              \
+    docs/man3/libpfm_arm_neoverse_n2.3
+endif # end of BUILD_PFMLIB_ARCH_ARM64
+
+if BUILD_PFMLIB_ARCH_MIPS
+man_MANS += docs/man3/libpfm_mips_74k.3
+endif # end of BUILD_PFMLIB_ARCH_MIPS
+
+if BUILD_PFMLIB_OS_LINUX
+man_MANS +=                                   \
+    docs/man3/pfm_get_perf_event_encoding.3   \
+    docs/man3/libpfm_perf_event_raw.3
+endif

--- a/examples/Makefile.mk
+++ b/examples/Makefile.mk
@@ -1,0 +1,22 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+EXTRA_PROGRAMS += $(examples_list)
+
+AM_CPPFLAGS += -I$(top_srcdir)/examples -D_GNU_SOURCE
+LDADD  += -lm
+
+if BUILD_PFMLIB_OS_LINUX
+AM_LDFLAGS += -pthread
+LDADD += -lrt
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+if BUILD_PFMLIB_OS_WINDOWS
+LDADD += -lgnurx
+endif # end of BUILD_PFMLIB_OS_WINDOWS
+
+examples_list +=            \
+    examples/showevtinfo    \
+    examples/check_events

--- a/include/Makefile.mk
+++ b/include/Makefile.mk
@@ -1,0 +1,15 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+AM_CPPFLAGS += -I$(top_srcdir)/include
+
+include_HEADERS +=                     \
+    include/perfmon/pfmlib.h           \
+    include/perfmon/pfmlib_perf_event.h
+
+if BUILD_PFMLIB_OS_LINUX
+include_HEADERS +=                     \
+    include/perfmon/perf_event.h
+endif # end of BUILD_PFMLIB_OS_LINUX

--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -1,0 +1,366 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+AM_CPPFLAGS += -D_REENTRANT -I$(topsrc_dir)/lib
+AM_CFLAGS   += -fvisibility=hidden
+
+# Common headers and sources
+noinst_HEADERS += lib/pfmlib_priv.h
+pfm_sources    += lib/pfmlib_common.c
+
+# Linux specific sources
+if BUILD_PFMLIB_OS_LINUX
+noinst_HEADERS += lib/events/perf_events.h
+
+pfm_sources +=                                  \
+    lib/pfmlib_perf_event_pmu.c                 \
+    lib/pfmlib_perf_event.c                     \
+    lib/pfmlib_perf_event_raw.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+if BUILD_PFMLIB_ARCH_IA64
+noinst_HEADERS +=                               \
+    lib/pfmlib_ia64_priv.h                      \
+    lib/events/itanium_events.h                 \
+    lib/events/itanium2_events.h                \
+    lib/events/montecito_events.h
+
+pfm_sources +=                                  \
+    #lib/pfmlib_gen_ia64.c                      \
+    #lib/pfmlib_itanium.c                       \
+    #lib/pfmlib_itanium2.c                      \
+    #lib/pfmlib_montecito.c
+endif # end of BUILD_PFMLIB_ARCH_IA64
+
+if BUILD_PFMLIB_ARCH_X86
+noinst_HEADERS +=                               \
+    lib/pfmlib_intel_x86_priv.h                 \
+    lib/pfmlib_amd64_priv.h                     \
+    lib/events/amd64_events_k7.h                \
+    lib/events/amd64_events_k8.h                \
+    lib/events/amd64_events_fam10h.h            \
+    lib/events/amd64_events_fam11h.h            \
+    lib/events/amd64_events_fam12h.h            \
+    lib/events/amd64_events_fam14h.h            \
+    lib/events/amd64_events_fam15h.h            \
+    lib/events/amd64_events_fam17h_zen1.h       \
+    lib/events/amd64_events_fam17h_zen2.h       \
+    lib/events/amd64_events_fam19h_zen3.h       \
+    lib/events/amd64_events_fam19h_zen4.h       \
+    lib/events/amd64_events_fam19h_zen3_l3.h    \
+    lib/events/amd64_events_fam16h.h            \
+    lib/events/intel_p6_events.h                \
+    lib/events/intel_netburst_events.h          \
+    lib/events/intel_x86_arch_events.h          \
+    lib/events/intel_coreduo_events.h           \
+    lib/events/intel_core_events.h              \
+    lib/events/intel_atom_events.h              \
+    lib/events/intel_nhm_events.h               \
+    lib/events/intel_nhm_unc_events.h           \
+    lib/events/intel_wsm_events.h               \
+    lib/events/intel_wsm_unc_events.h           \
+    lib/events/intel_snb_events.h               \
+    lib/events/intel_snb_unc_events.h           \
+    lib/events/intel_ivb_events.h               \
+    lib/events/intel_hsw_events.h               \
+    lib/events/intel_bdw_events.h               \
+    lib/events/intel_skl_events.h               \
+    lib/events/intel_glm_events.h               \
+    lib/events/intel_icl_events.h               \
+    lib/events/intel_spr_events.h               \
+    lib/pfmlib_intel_snbep_unc_priv.h           \
+    lib/events/intel_snbep_unc_cbo_events.h     \
+    lib/events/intel_snbep_unc_ha_events.h      \
+    lib/events/intel_snbep_unc_imc_events.h     \
+    lib/events/intel_snbep_unc_pcu_events.h     \
+    lib/events/intel_snbep_unc_qpi_events.h     \
+    lib/events/intel_snbep_unc_ubo_events.h     \
+    lib/events/intel_snbep_unc_r2pcie_events.h  \
+    lib/events/intel_snbep_unc_r3qpi_events.h   \
+    lib/events/intel_tmt_events.h               \
+    lib/events/intel_knc_events.h               \
+    lib/events/intel_knl_events.h               \
+    lib/events/intel_ivbep_unc_cbo_events.h     \
+    lib/events/intel_ivbep_unc_ha_events.h      \
+    lib/events/intel_ivbep_unc_imc_events.h     \
+    lib/events/intel_ivbep_unc_pcu_events.h     \
+    lib/events/intel_ivbep_unc_qpi_events.h     \
+    lib/events/intel_ivbep_unc_ubo_events.h     \
+    lib/events/intel_ivbep_unc_r2pcie_events.h  \
+    lib/events/intel_ivbep_unc_r3qpi_events.h   \
+    lib/events/intel_ivbep_unc_irp_events.h     \
+    lib/events/intel_hswep_unc_cbo_events.h     \
+    lib/events/intel_hswep_unc_sbo_events.h     \
+    lib/events/intel_hswep_unc_ha_events.h      \
+    lib/events/intel_hswep_unc_imc_events.h     \
+    lib/events/intel_hswep_unc_pcu_events.h     \
+    lib/events/intel_hswep_unc_qpi_events.h     \
+    lib/events/intel_hswep_unc_ubo_events.h     \
+    lib/events/intel_hswep_unc_r2pcie_events.h  \
+    lib/events/intel_hswep_unc_r3qpi_events.h   \
+    lib/events/intel_hswep_unc_irp_events.h     \
+    lib/events/intel_bdx_unc_cbo_events.h       \
+    lib/events/intel_bdx_unc_ubo_events.h       \
+    lib/events/intel_bdx_unc_sbo_events.h       \
+    lib/events/intel_bdx_unc_ha_events.h        \
+    lib/events/intel_bdx_unc_imc_events.h       \
+    lib/events/intel_bdx_unc_irp_events.h       \
+    lib/events/intel_bdx_unc_pcu_events.h       \
+    lib/events/intel_bdx_unc_qpi_events.h       \
+    lib/events/intel_bdx_unc_r2pcie_events.h    \
+    lib/events/intel_bdx_unc_r3qpi_events.h     \
+    lib/events/intel_skx_unc_cha_events.h       \
+    lib/events/intel_skx_unc_iio_events.h       \
+    lib/events/intel_skx_unc_imc_events.h       \
+    lib/events/intel_skx_unc_irp_events.h       \
+    lib/events/intel_skx_unc_m2m_events.h       \
+    lib/events/intel_skx_unc_m3upi_events.h     \
+    lib/events/intel_skx_unc_pcu_events.h       \
+    lib/events/intel_skx_unc_ubo_events.h       \
+    lib/events/intel_skx_unc_upi_events.h       \
+    lib/events/intel_knl_unc_imc_events.h       \
+    lib/events/intel_knl_unc_edc_events.h       \
+    lib/events/intel_knl_unc_cha_events.h       \
+    lib/events/intel_knl_unc_m2pcie_events.h    \
+    lib/events/intel_slm_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources +=                                  \
+    lib/pfmlib_intel_x86_perf_event.c           \
+    lib/pfmlib_amd64_perf_event.c               \
+    lib/pfmlib_intel_netburst_perf_event.c      \
+    lib/pfmlib_intel_snbep_unc_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources +=                                  \
+    lib/pfmlib_amd64.c                          \
+    lib/pfmlib_intel_core.c                     \
+    lib/pfmlib_intel_x86.c                      \
+    lib/pfmlib_intel_x86_arch.c                 \
+    lib/pfmlib_intel_atom.c                     \
+    lib/pfmlib_intel_nhm_unc.c                  \
+    lib/pfmlib_intel_nhm.c                      \
+    lib/pfmlib_intel_wsm.c                      \
+    lib/pfmlib_intel_snb.c                      \
+    lib/pfmlib_intel_snb_unc.c                  \
+    lib/pfmlib_intel_ivb.c                      \
+    lib/pfmlib_intel_ivb_unc.c                  \
+    lib/pfmlib_intel_hsw.c                      \
+    lib/pfmlib_intel_bdw.c                      \
+    lib/pfmlib_intel_skl.c                      \
+    lib/pfmlib_intel_icl.c                      \
+    lib/pfmlib_intel_spr.c                      \
+    lib/pfmlib_intel_rapl.c                     \
+    lib/pfmlib_intel_snbep_unc.c                \
+    lib/pfmlib_intel_snbep_unc_cbo.c            \
+    lib/pfmlib_intel_snbep_unc_ha.c             \
+    lib/pfmlib_intel_snbep_unc_imc.c            \
+    lib/pfmlib_intel_snbep_unc_pcu.c            \
+    lib/pfmlib_intel_snbep_unc_qpi.c            \
+    lib/pfmlib_intel_snbep_unc_ubo.c            \
+    lib/pfmlib_intel_snbep_unc_r2pcie.c         \
+    lib/pfmlib_intel_snbep_unc_r3qpi.c          \
+    lib/pfmlib_intel_ivbep_unc_cbo.c            \
+    lib/pfmlib_intel_ivbep_unc_ha.c             \
+    lib/pfmlib_intel_ivbep_unc_imc.c            \
+    lib/pfmlib_intel_ivbep_unc_pcu.c            \
+    lib/pfmlib_intel_ivbep_unc_qpi.c            \
+    lib/pfmlib_intel_ivbep_unc_ubo.c            \
+    lib/pfmlib_intel_ivbep_unc_r2pcie.c         \
+    lib/pfmlib_intel_ivbep_unc_r3qpi.c          \
+    lib/pfmlib_intel_ivbep_unc_irp.c            \
+    lib/pfmlib_intel_hswep_unc_cbo.c            \
+    lib/pfmlib_intel_hswep_unc_ha.c             \
+    lib/pfmlib_intel_hswep_unc_imc.c            \
+    lib/pfmlib_intel_hswep_unc_pcu.c            \
+    lib/pfmlib_intel_hswep_unc_qpi.c            \
+    lib/pfmlib_intel_hswep_unc_ubo.c            \
+    lib/pfmlib_intel_hswep_unc_r2pcie.c         \
+    lib/pfmlib_intel_hswep_unc_r3qpi.c          \
+    lib/pfmlib_intel_hswep_unc_irp.c            \
+    lib/pfmlib_intel_hswep_unc_sbo.c            \
+    lib/pfmlib_intel_bdx_unc_cbo.c              \
+    lib/pfmlib_intel_bdx_unc_ubo.c              \
+    lib/pfmlib_intel_bdx_unc_sbo.c              \
+    lib/pfmlib_intel_bdx_unc_ha.c               \
+    lib/pfmlib_intel_bdx_unc_imc.c              \
+    lib/pfmlib_intel_bdx_unc_irp.c              \
+    lib/pfmlib_intel_bdx_unc_pcu.c              \
+    lib/pfmlib_intel_bdx_unc_qpi.c              \
+    lib/pfmlib_intel_bdx_unc_r2pcie.c           \
+    lib/pfmlib_intel_bdx_unc_r3qpi.c            \
+    lib/pfmlib_intel_skx_unc_cha.c              \
+    lib/pfmlib_intel_skx_unc_iio.c              \
+    lib/pfmlib_intel_skx_unc_imc.c              \
+    lib/pfmlib_intel_skx_unc_irp.c              \
+    lib/pfmlib_intel_skx_unc_m2m.c              \
+    lib/pfmlib_intel_skx_unc_m3upi.c            \
+    lib/pfmlib_intel_skx_unc_pcu.c              \
+    lib/pfmlib_intel_skx_unc_ubo.c              \
+    lib/pfmlib_intel_skx_unc_upi.c              \
+    lib/pfmlib_intel_knc.c                      \
+    lib/pfmlib_intel_slm.c                      \
+    lib/pfmlib_intel_tmt.c                      \
+    lib/pfmlib_intel_knl.c                      \
+    lib/pfmlib_intel_knl_unc_imc.c              \
+    lib/pfmlib_intel_knl_unc_edc.c              \
+    lib/pfmlib_intel_knl_unc_cha.c              \
+    lib/pfmlib_intel_knl_unc_m2pcie.c           \
+    lib/pfmlib_intel_glm.c                      \
+    lib/pfmlib_intel_netburst.c                 \
+    lib/pfmlib_amd64_k7.c                       \
+    lib/pfmlib_amd64_k8.c                       \
+    lib/pfmlib_amd64_fam10h.c                   \
+    lib/pfmlib_amd64_fam11h.c                   \
+    lib/pfmlib_amd64_fam12h.c                   \
+    lib/pfmlib_amd64_fam14h.c                   \
+    lib/pfmlib_amd64_fam15h.c                   \
+    lib/pfmlib_amd64_fam17h.c                   \
+    lib/pfmlib_amd64_fam16h.c                   \
+    lib/pfmlib_amd64_fam19h.c                   \
+    lib/pfmlib_amd64_rapl.c                     \
+    lib/pfmlib_amd64_fam19h_l3.c
+
+if BUILD_PFMLIB_ARCH_I386
+pfm_sources +=                                  \
+    lib/pfmlib_intel_coreduo.c                  \
+    lib/pfmlib_intel_p6.c
+endif # end of BUILD_PFMLIB_ARCH_I386
+endif # end of BUILD_PFMLIB_ARCH_X86
+
+if BUILD_PFMLIB_ARCH_POWERPC
+noinst_HEADERS +=                               \
+    lib/events/ppc970mp_events.h                \
+    lib/events/power4_events.h                  \
+    lib/events/power5_events.h                  \
+    lib/events/power5+_events.h                 \
+    lib/events/power6_events.h                  \
+    lib/events/power7_events.h                  \
+    lib/events/power8_events.h                  \
+    lib/events/power9_events.h                  \
+    lib/events/power10_events.h                 \
+    lib/events/torrent_events.h                 \
+    lib/events/powerpc_nest_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources += lib/pfmlib_powerpc_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources +=                                  \
+    lib/pfmlib_powerpc.c                        \
+    lib/pfmlib_power4.c                         \
+    lib/pfmlib_ppc970.c                         \
+    lib/pfmlib_power5.c                         \
+    lib/pfmlib_power6.c                         \
+    lib/pfmlib_power7.c                         \
+    lib/pfmlib_torrent.c                        \
+    lib/pfmlib_power8.c                         \
+    lib/pfmlib_power9.c                         \
+    lib/pfmlib_power10.c                        \
+    lib/pfmlib_powerpc_nest.c
+endif # end of BUILD_PFMLIB_ARCH_POWERPC
+
+if BUILD_PFMLIB_ARCH_S390X
+noinst_HEADERS +=                               \
+    lib/pfmlib_s390x_priv.h                     \
+    lib/events/s390x_cpumf_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources += lib/pfmlib_s390x_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources += lib/pfmlib_s390x_cpumf.c
+endif # end of BUILD_PFMLIB_ARCH_S390X
+
+if BUILD_PFMLIB_ARCH_SPARC
+noinst_HEADERS +=                               \
+    lib/events/sparc_ultra12_events.h           \
+    lib/events/sparc_ultra3_events.h            \
+    lib/events/sparc_ultra3plus_events.h        \
+    lib/events/sparc_ultra3i_events.h           \
+    lib/events/sparc_ultra4plus_events.h        \
+    lib/events/sparc_niagara1_events.h          \
+    lib/events/sparc_niagara2_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources += lib/pfmlib_sparc_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources +=                                  \
+    lib/pfmlib_sparc.c                          \
+    lib/pfmlib_sparc_ultra12.c                  \
+    lib/pfmlib_sparc_ultra3.c                   \
+    lib/pfmlib_sparc_ultra4.c                   \
+    lib/pfmlib_sparc_niagara.c
+endif # end of BUILD_PFMLIB_ARCH_SPARC
+
+if BUILD_PFMLIB_ARCH_ARM
+noinst_HEADERS +=                               \
+    lib/pfmlib_arm_priv.h                       \
+    lib/events/arm_cortex_a7_events.h           \
+    lib/events/arm_cortex_a8_events.h           \
+    lib/events/arm_cortex_a9_events.h           \
+    lib/events/arm_cortex_a15_events.h          \
+    lib/events/arm_cortex_a57_events.h          \
+    lib/events/arm_cortex_a53_events.h          \
+    lib/events/arm_xgene_events.h               \
+    lib/events/arm_cavium_tx2_events.h          \
+    lib/events/arm_marvell_tx2_unc_events.h     \
+    lib/events/arm_neoverse_n1_events.h         \
+    lib/events/arm_neoverse_n2_events.h         \
+    lib/events/arm_hisilicon_kunpeng_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources += lib/pfmlib_arm_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources +=                                  \
+    lib/pfmlib_arm.c                            \
+    lib/pfmlib_arm_armv7_pmuv1.c                \
+    lib/pfmlib_arm_armv6.c                      \
+    lib/pfmlib_arm_armv8.c                      \
+    lib/pfmlib_tx2_unc_perf_event.c
+endif # end of BUILD_PFMLIB_ARCH_ARM
+
+if BUILD_PFMLIB_ARCH_ARM64
+noinst_HEADERS +=                               \
+    lib/events/arm_cortex_a57_events.h          \
+    lib/events/arm_cortex_a53_events.h          \
+    lib/events/arm_xgene_events.h               \
+    lib/events/arm_cavium_tx2_events.h          \
+    lib/events/arm_marvell_tx2_unc_events.h     \
+    lib/events/arm_fujitsu_a64fx_events.h       \
+    lib/events/arm_neoverse_n1_events.h         \
+    lib/events/arm_neoverse_n2_events.h         \
+    lib/events/arm_hisilicon_kunpeng_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources += lib/pfmlib_arm_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources +=                                  \
+    lib/pfmlib_arm.c                            \
+    lib/pfmlib_arm_armv8.c                      \
+    lib/pfmlib_tx2_unc_perf_event.c
+endif # end of BUILD_PFMLIB_ARCH_ARM64
+
+if BUILD_PFMLIB_ARCH_MIPS
+noinst_HEADERS += lib/events/mips_74k_events.h
+
+if BUILD_PFMLIB_OS_LINUX
+pfm_sources += lib/pfmlib_mips_perf_event.c
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+pfm_sources +=                                  \
+    lib/pfmlib_mips.c                           \
+    lib/pfmlib_mips_74k.c
+endif # end of BUILD_PFMLIB_ARCH_MIPS
+
+if BUILD_PFMLIB_ARCH_CELL
+cell_includes = lib/events/cell_events.h
+
+pfm_sources +=                                  \
+    #lib/pfmlib_cell.c
+endif # end of BUILD_PFMLIB_ARCH_CELL

--- a/maint/version.m4
+++ b/maint/version.m4
@@ -1,0 +1,5 @@
+[#] start of __file__
+
+m4_define([PFM_VERSION_m4],[4.12.0])
+
+[#] end of __file__

--- a/perf_examples/Makefile.mk
+++ b/perf_examples/Makefile.mk
@@ -1,0 +1,40 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+EXTRA_PROGRAMS += $(perf_examples_list)
+
+AM_CPPFLAGS += -I$(top_srcdir)/perf_examples -D_GNU_SOURCE
+AM_LDFLAGS  += -L$(top_builddir)/lib/.libs -pthread
+LDADD        = perf_examples/perf_util.o libpfm.la
+
+perf_examples_list +=                   \
+    perf_examples/self                  \
+    perf_examples/self_basic            \
+    perf_examples/self_count            \
+    perf_examples/task                  \
+    perf_examples/task_attach_timeout   \
+    perf_examples/syst                  \
+    perf_examples/notify_self           \
+    perf_examples/notify_group          \
+    perf_examples/task_smpl             \
+    perf_examples/self_smpl_multi       \
+    perf_examples/self_pipe             \
+    perf_examples/syst_count            \
+    perf_examples/task_cpu              \
+    perf_examples/syst_smpl             \
+    perf_examples/evt2raw               \
+    perf_examples/branch_smpl
+
+if BUILD_PFMLIB_ARCH_X86
+perf_examples_list += perf_examples/x86/bts_smpl
+endif
+
+if BUILD_PFMLIB_ARCH_I386
+perf_examples_list += perf_examples/x86/bts_smpl
+endif
+
+if BUILD_RTOP
+perf_examples_list += perf_examples/rtop
+endif

--- a/tests/Makefile.mk
+++ b/tests/Makefile.mk
@@ -1,0 +1,38 @@
+##
+## Copyright (C) by Hewlett-Packard Development Company, L.P.
+##     See copyright in top level directory
+##
+
+EXTRA_PROGRAMS += $(testlist)
+
+testlist += tests/validate
+
+tests_validate_SOURCES = tests/validate.c
+tests_validate_LDADD   = -lm libpfm.la
+
+if BUILD_PFMLIB_OS_LINUX
+tests_validate_SOURCES += tests/validate_perf.c
+tests_validate_CPPFLAGS = -I$(top_srcdir)/tests -I$(top_srcdir)/include -D_GNU_SOURCE
+tests_validate_LDFLAGS  = -L$(top_builddir)/lib/.libs
+tests_validate_CFLAGS   = -pthread
+endif # end of BUILD_PFMLIB_OS_LINUX
+
+if BUILD_PFMLIB_ARCH_X86
+tests_validate_SOURCES += tests/validate_x86.c
+endif # end of BUILD_PFMLIB_ARCH_X86
+
+if BUILD_PFMLIB_ARCH_MIPS
+tests_validate_SOURCES += tests/validate_mips.c
+endif # end of BUILD_PFMLIB_ARCH_MIPS
+
+if BUILD_PFMLIB_ARCH_ARM
+tests_validate_SOURCES += tests/validate_arm.c
+endif # end of BUILD_PFMLIB_ARCH_ARM
+
+if BUILD_PFMLIB_ARCH_ARM64
+tests_validate_SOURCES += tests/validate_arm64.c
+endif # end of BUILD_PFMLIB_ARCH_ARM64
+
+if BUILD_PFMLIB_ARCH_POWERPC
+tests_validate_SOURCES += tests/validate_power.c
+endif # end of BUILD_PFMLIB_ARCH_POWERPC


### PR DESCRIPTION
Autotools allows a number of improvements over the current build system. The most notable are:

 - Native support for out-of-tree builds. This easily simplifies building multiple versions of the library for different systems and/or configurations of hardware;
 - Native supports for all the MAKE targets;
 - Integrates better with other autotools projects;
 - Simplicity (no need to run make hierarchically and write complex rules)